### PR TITLE
Fixed minor typo in website documentation

### DIFF
--- a/node_modules/fresh/README.md
+++ b/node_modules/fresh/README.md
@@ -42,7 +42,7 @@ to make handling these requests transparent.
 
 This module is designed to only follow the HTTP specifications, not
 to work-around all kinda of client bugs (especially since this module
-typically does not recieve enough information to understand what the
+typically does not receive enough information to understand what the
 client actually is).
 
 There is a known issue that in certain versions of Safari, Safari

--- a/public/index.html
+++ b/public/index.html
@@ -282,7 +282,7 @@ strong {
   
           <div class="section-header">
               <h1>Leto Analytics: How it works</h2>
-              <p>Discover how Leto recieves, stores, and provides Analytics for the IPFS Ecosystem</p>
+              <p>Discover how Leto receives, stores, and provides Analytics for the IPFS Ecosystem</p>
           </div>
 
              <!-- Images added here -->

--- a/public/pages/pageTwo.html
+++ b/public/pages/pageTwo.html
@@ -64,7 +64,7 @@
   
           <div class="section-header">
               <h2>Leto Analytics: How it works</h2>
-              <p>Discover how Leto recieves, stores, and provides Analytics for the IPFS Ecosystem</p>
+              <p>Discover how Leto receives, stores, and provides Analytics for the IPFS Ecosystem</p>
           </div>
   
           <div class="col-lg-12">


### PR DESCRIPTION
Replaced all occurrences of 'recieve' with 'recieve'. 